### PR TITLE
Makefile: Append LDFLAGS to let user add external variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC = gcc
 CFLAGS += -g 
 #CFLAGS += -O2 -Wall -W -Werror
-LDFLAGS = -libverbs -lrdmacm -lmlx5
+LDFLAGS += -libverbs -lrdmacm -lmlx5
 TARGETS = dcping
 
 all:


### PR DESCRIPTION
This is useful when wanting to compile VS a non-default verbs library.